### PR TITLE
Update PublishUserDevice.php

### DIFF
--- a/src/commands/PublishUserDevice.php
+++ b/src/commands/PublishUserDevice.php
@@ -62,7 +62,7 @@ class PublishUserDevice extends Command
         $this->createFile($repoDir. DIRECTORY_SEPARATOR, 'UserDeviceRepository.php', $repoTemplate);
         $this->info('UserDeviceRepository published.');
 
-        $fileName = date('Y_m_d_His').'_'.'create_user_device_table.php';
+        $fileName = date('Y_m_d_His').'_'.'create_user_devices_table.php';
 
         $repoTemplate = file_get_contents(__DIR__.'/../stubs/CreateUserDeviceTable.stub');
         $this->createFile(base_path('database/migrations/'), $fileName, $repoTemplate);


### PR DESCRIPTION
The migration is thrown error (Laravel 8.83.23) : PHP Fatal error:  Cannot declare class CreateUserDevicesTable, because the name is already in use, because the missing "-s" in the $fileName variable line 65, more info related to this issue (https://stackoverflow.com/a/67595347)